### PR TITLE
열린 지뢰 타일을 새로운 섹션 생성할 때 적용할 수 있도록 수정

### DIFF
--- a/board/data/internal/section.py
+++ b/board/data/internal/section.py
@@ -77,14 +77,14 @@ class Section:
         self_idx = (self_y * Section.LENGTH) + self_x
         neighbor_idx = (neighbor_y * Section.LENGTH) + neighbor_x
 
-        if self.data[self_idx] == MINE_TILE:
+        if self.data[self_idx] & MINE_TILE:
             affect_origin_mines_to_new(
                 new_tiles=neighbor.data,
                 x_range=(neighbor_x, neighbor_x),
                 y_range=(neighbor_y, neighbor_y)
             )
 
-        if neighbor.data[neighbor_idx] == MINE_TILE:
+        if neighbor.data[neighbor_idx] & MINE_TILE:
             affect_new_mines_to_origin(
                 origin_tiles=self.data,
                 new_tiles=neighbor.data,
@@ -113,14 +113,14 @@ class Section:
             leftmost = max(0, x - 1)
             rightmost = min(x + 1, Section.LENGTH - 1)
 
-            if self.data[self_idx] == MINE_TILE:
+            if self.data[self_idx] & MINE_TILE:
                 affect_origin_mines_to_new(
                     new_tiles=neighbor.data,
                     x_range=(leftmost, rightmost),
                     y_range=(neighbor_y, neighbor_y)
                 )
 
-            if neighbor.data[neighbor_idx] == MINE_TILE:
+            if neighbor.data[neighbor_idx] & MINE_TILE:
                 affect_new_mines_to_origin(
                     origin_tiles=self.data,
                     new_tiles=neighbor.data,
@@ -149,14 +149,14 @@ class Section:
             top = min(y + 1, Section.LENGTH - 1)
             bottom = max(0, y - 1)
 
-            if self.data[self_idx] == MINE_TILE:
+            if self.data[self_idx] & MINE_TILE:
                 affect_origin_mines_to_new(
                     new_tiles=neighbor.data,
                     x_range=(neighbor_x, neighbor_x),
                     y_range=(bottom, top)
                 )
 
-            if neighbor.data[neighbor_idx] == MINE_TILE:
+            if neighbor.data[neighbor_idx] & MINE_TILE:
                 affect_new_mines_to_origin(
                     origin_tiles=self.data,
                     new_tiles=neighbor.data,
@@ -192,7 +192,7 @@ class Section:
                 cur_tile = data[rand_idx]
 
                 # 이미 지뢰가 존재
-                if cur_tile == MINE_TILE:
+                if cur_tile & MINE_TILE:
                     continue
 
                 # 주변 타일 검사
@@ -222,7 +222,7 @@ def affect_origin_mines_to_new(new_tiles: bytearray, x_range: tuple[int, int], y
             idx = (y * Section.LENGTH) + x
 
             tile = new_tiles[idx]
-            if tile == MINE_TILE:
+            if tile & MINE_TILE:
                 continue
 
             num = tile & NUM_MASK
@@ -250,7 +250,7 @@ def affect_new_mines_to_origin(
             idx = (y * Section.LENGTH) + x
 
             tile = origin_tiles[idx]
-            if tile == MINE_TILE:
+            if tile & MINE_TILE:
                 continue
 
             num = tile & NUM_MASK
@@ -278,7 +278,7 @@ def decrease_number_around_and_count_mines(tiles: bytearray, p: Point) -> int:
 
     def do(t: int, p: Point) -> tuple[int | None, bool]:
         nonlocal cnt
-        if t == MINE_TILE:
+        if t & MINE_TILE:
             cnt += 1
             return None, False
 
@@ -297,7 +297,7 @@ def remove_one_nearby_mine(tiles: bytearray, p: Point):
     그 주변 타일의 num은 1씩 감소한다.
     """
     def do(t: int, p: Point) -> tuple[int | None, bool]:
-        if t != MINE_TILE:
+        if not (t & MINE_TILE):
             return None, False
 
         cnt = decrease_number_around_and_count_mines(tiles=tiles, p=p)
@@ -311,7 +311,7 @@ def increase_number_around(tiles: bytearray, p: Point):
     주변 타일의 num을 1씩 증가시킨다.
     """
     def do(t: int, p: Point) -> tuple[int | None, bool]:
-        if t == MINE_TILE:
+        if t & MINE_TILE:
             return None, False
 
         t += 1

--- a/board/data/test/section_test.py
+++ b/board/data/test/section_test.py
@@ -166,7 +166,7 @@ class SectionApplyNeighborTestCase(unittest.TestCase):
         # 왼쪽 위 섹션: 오른쪽 끝을 감싸는 지뢰들
         self.left_top_section = Section(Point(-1, 1), data=bytearray([
             MINES_OF(0), MINES_OF(1), MINES_OF(2), MINES_OF(2),
-            MINES_OF(0), MINES_OF(2), MINE_TILE__, MINE_TILE__,
+            MINES_OF(0), MINES_OF(2), MINE_TILE__, OPEN_MINE__,
             MINES_OF(0), MINES_OF(3), MINE_TILE__, MINES_OF(5),
             MINES_OF(0), MINES_OF(2), MINE_TILE__, MINE_TILE__
         ]))
@@ -174,19 +174,19 @@ class SectionApplyNeighborTestCase(unittest.TestCase):
         self.right_top_section = Section(Point(0, 1), data=bytearray([
             MINES_OF(1), MINES_OF(1), MINES_OF(0), MINES_OF(0),
             MINE_TILE__, MINES_OF(2), MINES_OF(0), MINES_OF(0),
-            MINE_TILE__, MINES_OF(4), MINES_OF(1), MINES_OF(0),
-            MINE_TILE__, MINE_TILE__, MINES_OF(1), MINES_OF(0)
+            OPEN_MINE__, MINES_OF(4), MINES_OF(1), MINES_OF(0),
+            OPEN_MINE__, MINE_TILE__, MINES_OF(1), MINES_OF(0)
         ]))
         # 왼쪽 아래 섹션: 오른쪽 아래 끝단 2개 지뢰
         self.left_bottom_section = Section(Point(-1, 0), data=bytearray([
             MINES_OF(0), MINES_OF(0), MINES_OF(0), MINES_OF(0),
             MINES_OF(0), MINES_OF(0), MINES_OF(1), MINES_OF(1),
             MINES_OF(0), MINES_OF(0), MINES_OF(2), MINE_TILE__,
-            MINES_OF(0), MINES_OF(0), MINES_OF(2), MINE_TILE__
+            MINES_OF(0), MINES_OF(0), MINES_OF(2), OPEN_MINE__
         ]))
         # 오른쪽 아래 섹션: 왼쪽 위 끝단을 감싸는 지뢰들
         self.right_bottom_section = Section(Point(0, 0), data=bytearray([
-            MINES_OF(3), MINE_TILE__, MINES_OF(2), MINES_OF(0),
+            MINES_OF(3), OPEN_MINE__, MINES_OF(2), MINES_OF(0),
             MINE_TILE__, MINE_TILE__, MINES_OF(2), MINES_OF(0),
             MINES_OF(2), MINES_OF(2), MINES_OF(1), MINES_OF(0),
             MINES_OF(0), MINES_OF(0), MINES_OF(0), MINES_OF(0)
@@ -276,7 +276,7 @@ class SectionApplyNeighborTestCase(unittest.TestCase):
             self.right_top_section.data[8],  # x=0, y=1
             self.right_top_section.data[12],  # x=0, y=0
         ]
-        self.assertEqual(l.count(MINE_TILE__), 2)
+        self.assertEqual(l.count(MINE_TILE__) + l.count(OPEN_MINE__), 2)
 
     def test_apply_neighbor_num_overflow_right_left(self):
         self.right_top_section.apply_neighbor_horizontal(
@@ -293,10 +293,11 @@ class SectionApplyNeighborTestCase(unittest.TestCase):
             self.left_top_section.data[15],  # x=3, y=0
 
         ]
-        self.assertEqual(l.count(MINE_TILE__), 4)
+        self.assertEqual(l.count(MINE_TILE__) + l.count(OPEN_MINE__), 4)
 
 
 MINE_TILE__ = 0b01000000
+OPEN_MINE__ = 0b11000000
 
 
 def MINES_OF(n: int) -> int:


### PR DESCRIPTION
기존 동등 비교(==) 때문에 닫힌 지뢰만 number에 적용되고 있었습니다. 그래서 &로 바꾸어 열린 지뢰도 적용되도록 바꿨습니다.