### PR TITLE
타일 연쇄 열림 구현

### DIFF
--- a/board/data/handler/internal/board.py
+++ b/board/data/handler/internal/board.py
@@ -73,6 +73,11 @@ class BoardHandler:
 
     @staticmethod
     def open_tiles_cascade(p: Point) -> tuple[Point, Point, Tiles]:
+        """
+        지정된 타일부터 주변 타일들을 연쇄적으로 개방한다.
+        빈칸들과 빈칸과 인접한숫자 타일까지 개방하며, 섹션 가장자리 데이터가 새로운 섹션으로 인해 중간에 수정되는 것을 방지하기 위해
+        섹션을 사용할 때 인접 섹션이 존재하지 않으면 미리 만들어 놓는다.
+        """
         # 탐색하며 발견한 섹션들
         sections: list[Section] = []
 

--- a/board/data/handler/test/board_test.py
+++ b/board/data/handler/test/board_test.py
@@ -70,7 +70,7 @@ class BoardHandlerTestCase(unittest.TestCase):
 
         start_p, end_p, tiles = BoardHandler.open_tiles_cascade(p)
 
-        self.assertEqual(len(create_seciton_mock.mock_calls), 5)
+        self.assertEqual(len(create_seciton_mock.mock_calls), 20)
 
         self.assertEqual(start_p, Point(-1, 3))
         self.assertEqual(end_p, Point(3, -1))

--- a/board/data/handler/test/board_test.py
+++ b/board/data/handler/test/board_test.py
@@ -1,7 +1,9 @@
 import unittest
+from unittest.mock import patch, MagicMock
 from tests.utils import cases
-from board.data import Point, Tile
+from board.data import Point, Tile, Section
 from board.data.handler import BoardHandler
+from cursor.data import Color
 from .fixtures import setup_board
 
 FETCH_CASE = \
@@ -44,15 +46,77 @@ class BoardHandlerTestCase(unittest.TestCase):
 
         self.assertEqual(data,  expect)
 
-    def test_update_tile(self):
-        p = Point(-1, -1)
+    def test_open_tile(self):
+        p = Point(0, -2)
 
-        tile = Tile.from_int(0)
-        BoardHandler.update_tile(p=p, tile=tile)
+        result = BoardHandler.open_tile(p)
 
         tiles = BoardHandler.fetch(start=p, end=p)
+        tile = Tile.from_int(tiles.data[0])
 
-        self.assertEqual(tiles.data[0], tile.data)
+        self.assertTrue(tile.is_open)
+        self.assertEqual(tile, result)
+
+    @patch("board.data.Section.create")
+    def test_open_tiles_cascade(self, create_seciton_mock: MagicMock):
+        def stub_section_create(p: Point) -> Section:
+            return Section(
+                data=bytearray([0b10000000 for _ in range(Section.LENGTH ** 2)]),
+                p=p
+            )
+        create_seciton_mock.side_effect = stub_section_create
+
+        p = Point(0, 3)
+
+        start_p, end_p, tiles = BoardHandler.open_tiles_cascade(p)
+
+        self.assertEqual(len(create_seciton_mock.mock_calls), 5)
+
+        self.assertEqual(start_p, Point(-1, 3))
+        self.assertEqual(end_p, Point(3, -1))
+        self.assertEqual(tiles, BoardHandler.fetch(start=start_p, end=end_p))
+
+        OPEN_0 = 0b10000000
+        OPEN_1 = 0b10000001
+        CLOSED_1 = 0b00000001
+        BLUE_FLAG = 0b01110000
+        PURPLE_FLAG = 0b00111001
+
+        expected = bytearray([
+            OPEN_1, OPEN_0, OPEN_0, OPEN_0, OPEN_0,
+            OPEN_1, OPEN_1, OPEN_1, OPEN_1, OPEN_0,
+            OPEN_1, OPEN_1, BLUE_FLAG, OPEN_1, OPEN_0,
+            OPEN_0, OPEN_1, CLOSED_1, OPEN_1, OPEN_0,
+            OPEN_1, OPEN_1, PURPLE_FLAG, OPEN_1, OPEN_1
+        ])
+        self.assertEqual(tiles.data, expected)
+
+    def test_set_flag_state_true(self):
+        p = Point(0, -2)
+        color = Color.BLUE
+
+        result = BoardHandler.set_flag_state(p=p, state=True, color=color)
+
+        tiles = BoardHandler.fetch(start=p, end=p)
+        tile = Tile.from_int(tiles.data[0])
+
+        self.assertTrue(tile.is_flag)
+        self.assertEqual(tile.color, color)
+
+        self.assertEqual(tile, result)
+
+    def test_set_flag_state_false(self):
+        p = Point(1, -1)
+
+        result = BoardHandler.set_flag_state(p=p, state=False)
+
+        tiles = BoardHandler.fetch(start=p, end=p)
+        tile = Tile.from_int(tiles.data[0])
+
+        self.assertFalse(tile.is_flag)
+        self.assertIsNone(tile.color)
+
+        self.assertEqual(tile, result)
 
 
 if __name__ == "__main__":

--- a/board/event/handler/internal/board_handler.py
+++ b/board/event/handler/internal/board_handler.py
@@ -1,6 +1,6 @@
 import asyncio
 from event import EventBroker
-from board.data import Point, Tile
+from board.data import Point, Tile, Tiles
 from board.data.handler import BoardHandler
 from cursor.data import Color
 from message import Message
@@ -18,7 +18,9 @@ from message.payload import (
     MovableResultPayload,
     ClickType,
     InteractionEvent,
-    TileStateChangedPayload
+    TilesOpenedPayload,
+    SingleTileOpenedPayload,
+    FlagSetPayload
 )
 
 
@@ -74,6 +76,7 @@ class BoardEventHandler():
             Point(pointer.x+1, pointer.y-1)
         )
 
+        # 포인팅한 칸 포함 3x3칸 중 열린 칸이 존재하는지 확인
         pointable = False
         for tile in tiles.data:
             t = Tile.from_int(tile)
@@ -94,11 +97,11 @@ class BoardEventHandler():
 
         publish_coroutines.append(EventBroker.publish(pub_message))
 
-        cursor_pos = message.payload.cursor_position
-
         if not pointable:
             await asyncio.gather(*publish_coroutines)
             return
+
+        cursor_pos = message.payload.cursor_position
 
         # 인터랙션 범위 체크
         if \
@@ -110,7 +113,7 @@ class BoardEventHandler():
             return
 
         # 보드 상태 업데이트하기
-        tile = Tile.from_int(tiles.data[4])  # 3x3칸 중 가운데
+        tile = Tile.from_int(tiles.data[4])  # 3x3칸 중 가운데 = 포인팅한 타일
         click_type = message.payload.click_type
 
         if tile.is_open:
@@ -124,26 +127,51 @@ class BoardEventHandler():
                     await asyncio.gather(*publish_coroutines)
                     return
 
-                tile.is_open = True
+                if tile.number is None:
+                    # 빈 칸. 주변 칸 모두 열기.
+                    start_p, end_p, tiles = BoardHandler.open_tiles_cascade(pointer)
+                    tiles.hide_info()
+                    tile_str = tiles.to_str()
+
+                    pub_message = Message(
+                        event=InteractionEvent.TILES_OPENED,
+                        payload=TilesOpenedPayload(
+                            start_p=start_p,
+                            end_p=end_p,
+                            tiles=tile_str
+                        )
+                    )
+                    publish_coroutines.append(EventBroker.publish(pub_message))
+                else:
+                    tile = BoardHandler.open_tile(pointer)
+
+                    tile_str = Tiles(data=bytearray([tile.data])).to_str()
+
+                    pub_message = Message(
+                        event=InteractionEvent.SINGLE_TILE_OPENED,
+                        payload=SingleTileOpenedPayload(
+                            position=pointer,
+                            tile=tile_str
+                        )
+                    )
+                    publish_coroutines.append(EventBroker.publish(pub_message))
 
             # 깃발 꽂기/뽑기
             case ClickType.SPECIAL_CLICK:
-                color = message.payload.color
+                flag_state = not tile.is_flag
+                color = message.payload.color if flag_state else None
 
-                tile.is_flag = not tile.is_flag
-                tile.color = color if tile.is_flag else None
+                _ = BoardHandler.set_flag_state(p=pointer, state=flag_state, color=color)
 
-        BoardHandler.update_tile(pointer, tile)
-
-        pub_message = Message(
-            event=InteractionEvent.TILE_STATE_CHANGED,
-            payload=TileStateChangedPayload(
-                position=pointer,
-                tile=tile
-            )
-        )
-
-        publish_coroutines.append(EventBroker.publish(pub_message))
+                pub_message = Message(
+                    event=InteractionEvent.FLAG_SET,
+                    payload=FlagSetPayload(
+                        position=pointer,
+                        is_set=flag_state,
+                        color=color,
+                    )
+                )
+                publish_coroutines.append(EventBroker.publish(pub_message))
 
         await asyncio.gather(*publish_coroutines)
 

--- a/cursor/data/handler/internal/cursor_handler.py
+++ b/cursor/data/handler/internal/cursor_handler.py
@@ -64,7 +64,7 @@ class CursorHandler:
 
     # 커서 view에 tile이 포함되는가
     @staticmethod
-    def view_includes(p: Point, exclude_ids: list[str] = []) -> list[Cursor]:
+    def view_includes_point(p: Point, exclude_ids: list[str] = []) -> list[Cursor]:
         result = []
         for cursor_id in CursorHandler.cursor_dict:
             if cursor_id in exclude_ids:
@@ -74,6 +74,36 @@ class CursorHandler:
 
             # 커서 뷰 범위를 벗어나는가
             if not cursor.check_in_view(p):
+                continue
+
+            result.append(cursor)
+
+        return result
+
+    # 커서 view에 range가 포함되는가
+    @staticmethod
+    def view_includes_range(start: Point, end: Point, exclude_ids: list[str] = []) -> list[Cursor]:
+        result = []
+        for cursor_id in CursorHandler.cursor_dict:
+            if cursor_id in exclude_ids:
+                continue
+
+            cursor = CursorHandler.cursor_dict[cursor_id]
+
+            left_top = Point(
+                x=cursor.position.x - cursor.width,
+                y=cursor.position.y + cursor.height
+            )
+            right_bottom = Point(
+                x=cursor.position.x + cursor.width,
+                y=cursor.position.y - cursor.height
+            )
+
+            # left_top이 end보다 오른쪽 혹은 아래인가
+            if left_top.x > end.x or left_top.y < end.y:
+                continue
+            # right_bottom이 start 보다 왼쪽 혹은 위인가
+            if right_bottom.x < start.x or right_bottom.y > start.y:
                 continue
 
             result.append(cursor)

--- a/cursor/data/handler/test/cursor_handler_test.py
+++ b/cursor/data/handler/test/cursor_handler_test.py
@@ -105,8 +105,8 @@ class CursorHandlerTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(result), 1)
         self.assertIn("C", result)
 
-    def test_view_includes(self):
-        result = CursorHandler.view_includes(p=Point(-3, 0))
+    def test_view_includes_point(self):
+        result = CursorHandler.view_includes_point(p=Point(-3, 0))
 
         result = [c.conn_id for c in result]
 
@@ -114,13 +114,36 @@ class CursorHandlerTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIn("A", result)
         self.assertIn("B", result)
 
-    def test_view_includes_exclude_id(self):
-        result = CursorHandler.view_includes(p=Point(-3, 0), exclude_ids=["A"])
+    def test_view_includes_point_exclude_id(self):
+        result = CursorHandler.view_includes_point(p=Point(-3, 0), exclude_ids=["A"])
 
         result = [c.conn_id for c in result]
 
         self.assertEqual(len(result), 1)
         self.assertIn("B", result)
+
+    def test_view_includes_range(self):
+        start = Point(-3, 1)
+        end = Point(-2, 0)
+        result = CursorHandler.view_includes_range(start=start, end=end)
+
+        result = [c.conn_id for c in result]
+
+        self.assertEqual(len(result), 3)
+        self.assertIn("A", result)
+        self.assertIn("B", result)
+        self.assertIn("C", result)
+
+    def test_view_includes_range__exclude_id(self):
+        start = Point(-3, 1)
+        end = Point(-2, 0)
+        result = CursorHandler.view_includes_range(start=start, end=end, exclude_ids=["A"])
+
+        result = [c.conn_id for c in result]
+
+        self.assertEqual(len(result), 2)
+        self.assertIn("B", result)
+        self.assertIn("C", result)
 
     def test_add_watcher(self):
         CursorHandler.add_watcher(

--- a/cursor/event/handler/test/cursor_event_handler_test.py
+++ b/cursor/event/handler/test/cursor_event_handler_test.py
@@ -20,9 +20,10 @@ from message.payload import (
     MovableResultPayload,
     MovedPayload,
     InteractionEvent,
-    TileStateChangedPayload,
     YouDiedPayload,
-    TileUpdatedPayload,
+    SingleTileOpenedPayload,
+    TilesOpenedPayload,
+    FlagSetPayload,
     ConnClosedPayload,
     CursorQuitPayload,
     SetViewSizePayload,
@@ -32,7 +33,7 @@ from message.payload import (
 from .fixtures import setup_cursor_locations
 import unittest
 from unittest.mock import AsyncMock, patch
-from board.data import Point, Tile
+from board.data import Point, Tile, Tiles
 
 """
 CursorEventHandler Test
@@ -853,75 +854,76 @@ class CursorEventHandler_TileStateChanged_TestCase(unittest.IsolatedAsyncioTestC
         CursorHandler.watchers = {}
         CursorHandler.watching = {}
 
+    # @patch("event.EventBroker.publish")
+    # async def test_receive_tile_state_changed(self, mock: AsyncMock):
+    #     position = Point(-4, -3)
+    #     tile = Tile.from_int(0b00100111)  # not open, flag, 7
+
+    #     message: Message[TileStateChangedPayload] = Message(
+    #         event=InteractionEvent.TILE_STATE_CHANGED,
+    #         payload=TileStateChangedPayload(
+    #             position=position,
+    #             tile=tile
+    #         )
+    #     )
+
+    #     await CursorEventHandler.receive_tile_state_changed(message)
+
+    #     # tile-updated 발행 확인
+    #     self.assertEqual(len(mock.mock_calls), 1)
+
+    #     # tile-updated
+    #     got: Message[TileUpdatedPayload] = mock.mock_calls[0].args[0]
+    #     self.assertEqual(type(got), Message)
+    #     self.assertEqual(got.event, "multicast")
+    #     # origin_event
+    #     self.assertIn("origin_event", got.header)
+    #     self.assertEqual(got.header["origin_event"], InteractionEvent.TILE_UPDATED)
+    #     # target_conns 확인, [A, B]
+    #     self.assertIn("target_conns", got.header)
+    #     self.assertEqual(len(got.header["target_conns"]), 2)
+    #     self.assertIn("A", got.header["target_conns"])
+    #     self.assertIn("B", got.header["target_conns"])
+    #     # payload 확인
+    #     self.assertEqual(type(got.payload), TileUpdatedPayload)
+    #     self.assertEqual(got.payload.position, position)
+    #     self.assertEqual(got.payload.tile, tile.copy(hide_info=True))
+
     @patch("event.EventBroker.publish")
-    async def test_receive_tile_state_changed(self, mock: AsyncMock):
-        position = Point(-4, -3)
-        tile = Tile.from_int(0b00100111)  # not open, flag, 7
-
-        message: Message[TileStateChangedPayload] = Message(
-            event=InteractionEvent.TILE_STATE_CHANGED,
-            payload=TileStateChangedPayload(
-                position=position,
-                tile=tile
-            )
-        )
-
-        await CursorEventHandler.receive_tile_state_changed(message)
-
-        # tile-updated 발행 확인
-        self.assertEqual(len(mock.mock_calls), 1)
-
-        # tile-updated
-        got: Message[TileUpdatedPayload] = mock.mock_calls[0].args[0]
-        self.assertEqual(type(got), Message)
-        self.assertEqual(got.event, "multicast")
-        # origin_event
-        self.assertIn("origin_event", got.header)
-        self.assertEqual(got.header["origin_event"], InteractionEvent.TILE_UPDATED)
-        # target_conns 확인, [A, B]
-        self.assertIn("target_conns", got.header)
-        self.assertEqual(len(got.header["target_conns"]), 2)
-        self.assertIn("A", got.header["target_conns"])
-        self.assertIn("B", got.header["target_conns"])
-        # payload 확인
-        self.assertEqual(type(got.payload), TileUpdatedPayload)
-        self.assertEqual(got.payload.position, position)
-        self.assertEqual(got.payload.tile, tile.copy(hide_info=True))
-
-    @patch("event.EventBroker.publish")
-    async def test_receive_tile_state_changed_mine_boom(self, mock: AsyncMock):
+    async def test_receive_single_tile_open(self, mock: AsyncMock):
         position = Point(-4, -3)
         tile = Tile.from_int(0b11000000)  # open, mine
+        tile_str = Tiles(data=bytearray([tile.data])).to_str()
 
-        message: Message[TileStateChangedPayload] = Message(
-            event=InteractionEvent.TILE_STATE_CHANGED,
-            payload=TileStateChangedPayload(
+        message: Message[SingleTileOpenedPayload] = Message(
+            event=InteractionEvent.SINGLE_TILE_OPENED,
+            payload=SingleTileOpenedPayload(
                 position=position,
-                tile=tile
+                tile=tile_str
             )
         )
 
-        await CursorEventHandler.receive_tile_state_changed(message)
+        await CursorEventHandler.receive_single_tile_opened(message)
 
-        # tile-updated, you-died 발행 확인
+        # single-tile-opened, you-died 발행 확인
         self.assertEqual(len(mock.mock_calls), 2)
 
-        # tile-updated
-        got: Message[TileUpdatedPayload] = mock.mock_calls[0].args[0]
+        # single-tile-opened
+        got: Message[SingleTileOpenedPayload] = mock.mock_calls[0].args[0]
         self.assertEqual(type(got), Message)
         self.assertEqual(got.event, "multicast")
         # origin_event
         self.assertIn("origin_event", got.header)
-        self.assertEqual(got.header["origin_event"], InteractionEvent.TILE_UPDATED)
+        self.assertEqual(got.header["origin_event"], InteractionEvent.SINGLE_TILE_OPENED)
         # target_conns 확인, [A, B]
         self.assertIn("target_conns", got.header)
         self.assertEqual(len(got.header["target_conns"]), 2)
         self.assertIn("A", got.header["target_conns"])
         self.assertIn("B", got.header["target_conns"])
         # payload 확인
-        self.assertEqual(type(got.payload), TileUpdatedPayload)
+        self.assertEqual(type(got.payload), SingleTileOpenedPayload)
         self.assertEqual(got.payload.position, position)
-        self.assertEqual(got.payload.tile.data, tile.data)
+        self.assertEqual(bytearray.fromhex(got.payload.tile)[0], tile.data)
 
         # you-died
         got: Message[YouDiedPayload] = mock.mock_calls[1].args[0]

--- a/cursor/event/handler/test/cursor_event_handler_test.py
+++ b/cursor/event/handler/test/cursor_event_handler_test.py
@@ -854,40 +854,43 @@ class CursorEventHandler_TileStateChanged_TestCase(unittest.IsolatedAsyncioTestC
         CursorHandler.watchers = {}
         CursorHandler.watching = {}
 
-    # @patch("event.EventBroker.publish")
-    # async def test_receive_tile_state_changed(self, mock: AsyncMock):
-    #     position = Point(-4, -3)
-    #     tile = Tile.from_int(0b00100111)  # not open, flag, 7
+    @patch("event.EventBroker.publish")
+    async def test_receive_flag_set(self, mock: AsyncMock):
+        position = Point(-4, -3)
+        color = Color.BLUE
+        is_set = True
 
-    #     message: Message[TileStateChangedPayload] = Message(
-    #         event=InteractionEvent.TILE_STATE_CHANGED,
-    #         payload=TileStateChangedPayload(
-    #             position=position,
-    #             tile=tile
-    #         )
-    #     )
+        message: Message[FlagSetPayload] = Message(
+            event=InteractionEvent.FLAG_SET,
+            payload=FlagSetPayload(
+                position=position,
+                color=color,
+                is_set=is_set
+            )
+        )
 
-    #     await CursorEventHandler.receive_tile_state_changed(message)
+        await CursorEventHandler.receive_flag_set(message)
 
-    #     # tile-updated 발행 확인
-    #     self.assertEqual(len(mock.mock_calls), 1)
+        # flag-set 발행 확인
+        self.assertEqual(len(mock.mock_calls), 1)
 
-    #     # tile-updated
-    #     got: Message[TileUpdatedPayload] = mock.mock_calls[0].args[0]
-    #     self.assertEqual(type(got), Message)
-    #     self.assertEqual(got.event, "multicast")
-    #     # origin_event
-    #     self.assertIn("origin_event", got.header)
-    #     self.assertEqual(got.header["origin_event"], InteractionEvent.TILE_UPDATED)
-    #     # target_conns 확인, [A, B]
-    #     self.assertIn("target_conns", got.header)
-    #     self.assertEqual(len(got.header["target_conns"]), 2)
-    #     self.assertIn("A", got.header["target_conns"])
-    #     self.assertIn("B", got.header["target_conns"])
-    #     # payload 확인
-    #     self.assertEqual(type(got.payload), TileUpdatedPayload)
-    #     self.assertEqual(got.payload.position, position)
-    #     self.assertEqual(got.payload.tile, tile.copy(hide_info=True))
+        # flag-set
+        got: Message[FlagSetPayload] = mock.mock_calls[0].args[0]
+        self.assertEqual(type(got), Message)
+        self.assertEqual(got.event, "multicast")
+        # origin_event
+        self.assertIn("origin_event", got.header)
+        self.assertEqual(got.header["origin_event"], InteractionEvent.FLAG_SET)
+        # target_conns 확인, [A, B]
+        self.assertIn("target_conns", got.header)
+        self.assertEqual(len(got.header["target_conns"]), 2)
+        self.assertIn("A", got.header["target_conns"])
+        self.assertIn("B", got.header["target_conns"])
+        # payload 확인
+        self.assertEqual(type(got.payload), FlagSetPayload)
+        self.assertEqual(got.payload.position, position)
+        self.assertEqual(got.payload.color, color)
+        self.assertEqual(got.payload.is_set, is_set)
 
     @patch("event.EventBroker.publish")
     async def test_receive_single_tile_open(self, mock: AsyncMock):

--- a/message/payload/__init__.py
+++ b/message/payload/__init__.py
@@ -5,5 +5,5 @@ from .internal.new_conn_payload import NewConnPayload, NewConnEvent, CursorPaylo
 from .internal.parsable_payload import ParsablePayload
 from .internal.pointing_payload import PointerSetPayload, PointingResultPayload, PointingPayload, TryPointingPayload, PointEvent, ClickType
 from .internal.move_payload import MoveEvent, MovingPayload, MovedPayload, CheckMovablePayload, MovableResultPayload
-from .internal.interaction_payload import TileStateChangedPayload, TileUpdatedPayload, YouDiedPayload, InteractionEvent
+from .internal.interaction_payload import YouDiedPayload, InteractionEvent, SingleTileOpenedPayload, TilesOpenedPayload, FlagSetPayload
 from .internal.error_payload import ErrorEvent, ErrorPayload

--- a/message/payload/internal/interaction_payload.py
+++ b/message/payload/internal/interaction_payload.py
@@ -35,4 +35,4 @@ class TilesOpenedPayload(Payload):
 class FlagSetPayload(Payload):
     position: ParsablePayload[Point]
     is_set: bool
-    color: Color
+    color: Color | None

--- a/message/payload/internal/interaction_payload.py
+++ b/message/payload/internal/interaction_payload.py
@@ -1,14 +1,16 @@
 from .base_payload import Payload
 from .parsable_payload import ParsablePayload
 from board.data import Point, Tile
+from cursor.data import Color
 from dataclasses import dataclass
 from enum import Enum
 
 
 class InteractionEvent(str, Enum):
     YOU_DIED = "you-died"
-    TILE_UPDATED = "tile-updated"
-    TILE_STATE_CHANGED = "tile-state-changed"
+    SINGLE_TILE_OPENED = "single-tile-opened"
+    TILES_OPENED = "tiles-opened"
+    FLAG_SET = "flag-set"
 
 
 @dataclass
@@ -17,12 +19,20 @@ class YouDiedPayload(Payload):
 
 
 @dataclass
-class TileUpdatedPayload(Payload):
+class SingleTileOpenedPayload(Payload):
     position: ParsablePayload[Point]
-    tile: ParsablePayload[Tile]
+    tile: str
 
 
 @dataclass
-class TileStateChangedPayload(Payload):
+class TilesOpenedPayload(Payload):
+    start_p: ParsablePayload[Point]
+    end_p: ParsablePayload[Point]
+    tiles: str
+
+
+@dataclass
+class FlagSetPayload(Payload):
     position: ParsablePayload[Point]
-    tile: ParsablePayload[Tile]
+    is_set: bool
+    color: Color


### PR DESCRIPTION
구현을 위해 이벤트 전달 방식을 바꿨습니다.
이제 모든 변경이 `tile-updated` 대신 각각의 이벤트를 가집니다.

- `flag-set`: 깃발 set/unset 이벤트
- `single-tile-opened`: 타일 하나 열림. mine일 수 있음.
- `tiles-opened`: 빈 칸을 열어 연쇄적으로 타일이 열림.

tiles-opened 이벤트는 현재 tiles 와 똑같은 형태이지만, 추후 사용형태가 변경될 것을 고려하여 새로 만들었습니다.

위 이벤트는 모두 BoardEventHandler에서 발행하며, CursorEventHandler에서 받아 커서를 골라 multicast로 다시 보냅니다.
`tiles-opened`는 `view_includes`의 범위 쿼리가 필요하여 `view_includes_range` 쿼리를 추가했습니다. 

<img width="1044" alt="image" src="https://github.com/user-attachments/assets/1e5bc556-7e45-43ab-8c5b-6cf2bacdf7e8" />

<br>
<br>
타일 연쇄 열기 알고리즘은 BFS로, 포인팅 지점부터 뻗어나가며 필요하다면 새로운 섹션을 추가합니다.
알고리즘 중간에 각 꼭짓점 위치를 계산하여 반환할 사각형 범위를 구합니다.
타일 열기가 모두 끝난 후, 구한 범위의 타일들을 fetch해와 같이 반환합니다.

