### PR TITLE
클라이언트에 커서 revive_at 전달 + cursors-died 이벤트

### DIFF
--- a/cursor/event/handler/internal/cursor_event_handler.py
+++ b/cursor/event/handler/internal/cursor_event_handler.py
@@ -360,10 +360,15 @@ class CursorEventHandler:
             publish_coroutines.append(EventBroker.publish(pub_message))
 
             # 보고있는 커서들에게 cursors-died
+            watcher_ids: set[str] = set()
+            for cursor in nearby_cursors:
+                temp_watcher_ids = CursorHandler.get_watchers(cursor_id=cursor.conn_id)
+                watcher_ids.update(temp_watcher_ids + [cursor.conn_id])
+
             pub_message = Message(
                 event="multicast",
                 header={
-                    "target_conns": [c.conn_id for c in view_cursors],
+                    "target_conns": [id for id in watcher_ids],
                     "origin_event": InteractionEvent.CURSORS_DIED
                 },
                 payload=CursorsDiedPayload(

--- a/cursor/event/handler/test/cursor_event_handler_test.py
+++ b/cursor/event/handler/test/cursor_event_handler_test.py
@@ -966,10 +966,9 @@ class CursorEventHandler_TileStateChanged_TestCase(unittest.IsolatedAsyncioTestC
         # origin_event
         self.assertIn("origin_event", got.header)
         self.assertEqual(got.header["origin_event"], InteractionEvent.CURSORS_DIED)
-        # target_conns 확인, [A, B]
+        # target_conns 확인, [B]
         self.assertIn("target_conns", got.header)
-        self.assertEqual(len(got.header["target_conns"]), 2)
-        self.assertIn("A", got.header["target_conns"])
+        self.assertEqual(len(got.header["target_conns"]), 1)
         self.assertIn("B", got.header["target_conns"])
         # payload 확인
         self.assertEqual(type(got.payload), CursorsDiedPayload)

--- a/message/payload/__init__.py
+++ b/message/payload/__init__.py
@@ -1,9 +1,9 @@
 from .internal.tiles_payload import FetchTilesPayload, TilesPayload, TilesEvent
 from .internal.base_payload import Payload
 from .internal.exceptions import InvalidFieldException, MissingFieldException, DumbHumanException
-from .internal.new_conn_payload import NewConnPayload, NewConnEvent, CursorPayload, CursorsPayload, MyCursorPayload, ConnClosedPayload, CursorQuitPayload, SetViewSizePayload, NewCursorCandidatePayload
+from .internal.new_conn_payload import NewConnPayload, NewConnEvent, CursorPayload, CursorReviveAtPayload, CursorsPayload, MyCursorPayload, ConnClosedPayload, CursorQuitPayload, SetViewSizePayload, NewCursorCandidatePayload
 from .internal.parsable_payload import ParsablePayload
 from .internal.pointing_payload import PointerSetPayload, PointingResultPayload, PointingPayload, TryPointingPayload, PointEvent, ClickType
 from .internal.move_payload import MoveEvent, MovingPayload, MovedPayload, CheckMovablePayload, MovableResultPayload
-from .internal.interaction_payload import YouDiedPayload, InteractionEvent, SingleTileOpenedPayload, TilesOpenedPayload, FlagSetPayload
+from .internal.interaction_payload import YouDiedPayload, InteractionEvent, SingleTileOpenedPayload, TilesOpenedPayload, FlagSetPayload, CursorsDiedPayload
 from .internal.error_payload import ErrorEvent, ErrorPayload

--- a/message/payload/internal/interaction_payload.py
+++ b/message/payload/internal/interaction_payload.py
@@ -1,5 +1,6 @@
 from .base_payload import Payload
 from .parsable_payload import ParsablePayload
+from .new_conn_payload import CursorPayload
 from board.data import Point, Tile
 from cursor.data import Color
 from dataclasses import dataclass
@@ -8,6 +9,7 @@ from enum import Enum
 
 class InteractionEvent(str, Enum):
     YOU_DIED = "you-died"
+    CURSORS_DIED = "cursors-died"
     SINGLE_TILE_OPENED = "single-tile-opened"
     TILES_OPENED = "tiles-opened"
     FLAG_SET = "flag-set"
@@ -16,6 +18,12 @@ class InteractionEvent(str, Enum):
 @dataclass
 class YouDiedPayload(Payload):
     revive_at: str
+
+
+@dataclass
+class CursorsDiedPayload(Payload):
+    revive_at: str
+    cursors: list[CursorPayload]
 
 
 @dataclass

--- a/message/payload/internal/new_conn_payload.py
+++ b/message/payload/internal/new_conn_payload.py
@@ -39,8 +39,13 @@ class CursorPayload(Payload):
 
 
 @dataclass
+class CursorReviveAtPayload(CursorPayload):
+    revive_at: str | None
+
+
+@dataclass
 class CursorsPayload(Payload):
-    cursors: list[CursorPayload]
+    cursors: list[CursorReviveAtPayload]
 
 
 class MyCursorPayload(CursorPayload):


### PR DESCRIPTION
커서 revive_at을 전달하여 클라이언트측에서 다른 커서들의 스턴 상태를 확인할 수 있도록 합니다.

- CursorPayload를 상속하여 revive_at을 추가한 CursorReviveAtPayload 추가
- CursorReviveAtPayload를 CursorsPayload에서 사용

또한 지뢰가 터질 시 다른 커서들에게 스턴 커서들을 알리는 `cursors-died` 이벤트를 만들었습니다.
