### PR TITLE
EventRecorder 추가

### DIFF
--- a/event/__init__.py
+++ b/event/__init__.py
@@ -1,2 +1,3 @@
 from .internal.event_broker import EventBroker, Receiver
+from .internal.event_recorder import EventRecorder
 from .internal.exceptions import NoMatchingReceiverException

--- a/event/internal/event_recorder.py
+++ b/event/internal/event_recorder.py
@@ -1,0 +1,38 @@
+from message import Message
+from db import db
+from datetime import datetime
+import asyncio
+import json
+
+TABLE_NAME = "events"
+
+
+async def init_table():
+    await db.execute(f"""
+    CREATE TABLE IF NOT EXISTS {TABLE_NAME}(
+        event TEXT NOT NULL,
+        timestamp FLOAT NOT NULL,
+        header TEXT NOT NULL,
+        payload TEXT NOT NULL
+    )""")
+
+asyncio.run(init_table())
+
+
+class EventRecorder:
+    async def record(timestamp: datetime, msg: Message):
+        header = json.dumps(obj=msg.header, sort_keys=True)
+        payload = json.dumps(obj=msg.payload, default=lambda o: o.__dict__, sort_keys=True)
+
+        await db.execute(
+            f"""
+                INSERT INTO {TABLE_NAME} (event, timestamp, header, payload)
+                VALUES (:event, :timestamp, :header, :payload)
+            """,
+            {
+                "event": msg.event,
+                "timestamp": timestamp.timestamp(),
+                "header": header,
+                "payload": payload
+            }
+        )

--- a/event/test/__init__.py
+++ b/event/test/__init__.py
@@ -1,4 +1,5 @@
 from .event_broker_test import EventBrokerTestCase
+from .event_recorder_test import EventRecorderTestCase
 
 import unittest
 

--- a/event/test/event_recorder_test.py
+++ b/event/test/event_recorder_test.py
@@ -1,0 +1,35 @@
+import unittest
+
+from event import EventRecorder
+
+from message import Message
+from message.payload import ErrorEvent, ErrorPayload
+from .utils import clear_records
+
+from datetime import datetime
+
+
+class EventRecorderTestCase(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        await clear_records()
+
+    async def asyncTearDown(self):
+        await clear_records()
+
+    async def test_record(self):
+        message = Message(
+            event=ErrorEvent.ERROR,
+            header={
+                "ayo": "pizza here",
+                "thisisint": 1
+            },
+            payload=ErrorPayload(msg="heelo world")
+        )
+
+        timestamp = datetime.now()
+
+        await EventRecorder.record(timestamp, message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/event/test/utils.py
+++ b/event/test/utils.py
@@ -1,0 +1,5 @@
+from db import db
+
+
+async def clear_records():
+    await db.execute("DELETE FROM events")

--- a/server_test.py
+++ b/server_test.py
@@ -4,10 +4,11 @@ from fastapi.websockets import WebSocketDisconnect
 from server import app
 from message import Message
 from message.payload import FetchTilesPayload, TilesPayload, TilesEvent, NewConnEvent
-from board.data.storage.test.fixtures import setup_board
+from board.data.storage.test.fixtures import setup_board, teardown_board
 from board.event.handler import BoardEventHandler
 from board.data import Point, Tile, Tiles
 from event import EventBroker
+from event.test.utils import clear_records
 from conn.manager import ConnectionManager
 
 import unittest
@@ -19,7 +20,9 @@ class ServerTestCase(unittest.IsolatedAsyncioTestCase):
         await setup_board()
         self.client = TestClient(app)
 
-    def tearDown(self):
+    async def asyncTearDown(self):
+        await teardown_board()
+        await clear_records()
         self.client.params = {}
         self.client.close()
 


### PR DESCRIPTION
#92 가 병합된 후 리뷰 부탁드립니다.

- EventRecorder 클래스를 추가하여 모든 event 기록
- 기존에 event 출력하던 _debug() 메서드 제거 -> 이제 서버 로그에 이벤트가 출력되지 않음

고려 사항:
- multicast와 broadcast 이벤트는 어떻게 처리하는게 좋을까요? 실제 이벤트는 header에 명시되어 있어서 쿼리하기 쉽지 않을 것으로 보입니다.
- 기록된 event를 이용해 진행상황을 다시 시뮬레이팅 하려면, random의 seed를 직접 넣어줘야 할 것입니다. (예: 커서 스폰 위치 결정)