### PR TITLE
커넥션에 rate limit 적용

### DIFF
--- a/.dev.env
+++ b/.dev.env
@@ -1,3 +1,4 @@
 MINE_KILL_DURATION_SECONDS=60
 DATABASE_PATH="./gamulpung.db"
 VIEW_SIZE_LIMIT=200
+MESSAGE_RATE_LIMIT="4/second" # [count] [per|/] [n (optional)] [second|minute|hour|day|month|year]

--- a/config.py
+++ b/config.py
@@ -9,3 +9,4 @@ if os.environ.get("ENV") != "prod":
 MINE_KILL_DURATION_SECONDS: int = int(os.environ.get("MINE_KILL_DURATION_SECONDS"))
 DATABASE_PATH: str = os.environ.get("DATABASE_PATH")
 VIEW_SIZE_LIMIT: int = int(os.environ.get("VIEW_SIZE_LIMIT"))
+MESSAGE_RATE_LIMIT = os.environ.get("MESSAGE_RATE_LIMIT")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ anyio==4.6.2.post1
 certifi==2024.8.30
 click==8.1.7
 colorama==0.4.6
+Deprecated==1.2.15
 fastapi==0.115.5
 gitdb==4.0.11
 GitPython==3.1.41
@@ -12,6 +13,8 @@ httpcore==1.0.7
 httptools==0.6.4
 httpx==0.27.2
 idna==3.10
+limits==3.14.1
+packaging==24.2
 pydantic==2.9.2
 pydantic_core==2.23.4
 python-dotenv==1.0.1
@@ -24,3 +27,4 @@ typing_extensions==4.12.2
 uvicorn==0.32.0
 watchfiles==0.24.0
 websockets==14.1
+wrapt==1.17.0

--- a/server.py
+++ b/server.py
@@ -38,9 +38,8 @@ async def session(ws: WebSocket):
 
     while True:
         try:
-            message = await conn.receive()
-            message.header = {"sender": conn.id}
-            await ConnectionManager.handle_message(message)
+            msg = await conn.receive()
+            await ConnectionManager.publish_client_event(conn_id=conn.id, msg=msg)
         except (WebSocketDisconnect, ConnectionClosed) as e:
             # 연결 종료됨
             break
@@ -50,7 +49,7 @@ async def session(ws: WebSocket):
                 payload=ErrorPayload(msg=e)
             ))
 
-            print(f"Unhandled error while handling message: \n{message.__dict__}\n{type(e)}: '{e}'")
+            print(f"Unhandled error while handling message: \n{msg.__dict__}\n{type(e)}: '{e}'")
             break
 
     await ConnectionManager.close(conn)


### PR DESCRIPTION
[limits](https://limits.readthedocs.io/en/stable/index.html) 라이브러리를 사용하여 connection의 메시지 발행에 rate limit을 걸었습니다.
단위 시간 당 N번 요청을 허용하는 방식입니다. 따라서 단시간에 폭발적으로 요청이 들어오는 것을 막지 못합니다. 