### PR TITLE
cursor revive at 관리를 cursor 내부로 변경

### DIFF
--- a/cursor/data/handler/test/cursor_handler_test.py
+++ b/cursor/data/handler/test/cursor_handler_test.py
@@ -20,8 +20,7 @@ class CursorHandlerTestCase(unittest.IsolatedAsyncioTestCase):
                 pointer=None,
                 height=6,
                 width=6,
-                color=Color.BLUE,
-                revive_at=None
+                color=Color.BLUE
             ),
             "B": Cursor(
                 conn_id="B",
@@ -29,8 +28,7 @@ class CursorHandlerTestCase(unittest.IsolatedAsyncioTestCase):
                 pointer=None,
                 height=7,
                 width=7,
-                color=Color.BLUE,
-                revive_at=None
+                color=Color.BLUE
             ),
             "C": Cursor(
                 conn_id="C",
@@ -38,8 +36,7 @@ class CursorHandlerTestCase(unittest.IsolatedAsyncioTestCase):
                 pointer=None,
                 height=4,
                 width=4,
-                color=Color.BLUE,
-                revive_at=None
+                color=Color.BLUE
             )
         }
 

--- a/cursor/data/internal/cursor.py
+++ b/cursor/data/internal/cursor.py
@@ -12,7 +12,18 @@ class Cursor:
     color: Color
     width: int
     height: int
-    revive_at: datetime | None
+    _revive_at: datetime | None = None
+
+    @property
+    def revive_at(self) -> datetime | None:
+        if (self._revive_at is not None) and (self._revive_at <= datetime.now()):
+            self._revive_at = None
+
+        return self._revive_at
+
+    @revive_at.setter
+    def revive_at(self, v: datetime) -> None:
+        self._revive_at = v
 
     def set_size(self, width: int, height: int):
         self.width = width
@@ -47,6 +58,5 @@ class Cursor:
             pointer=None,
             color=Color.get_random(),
             width=0,
-            height=0,
-            revive_at=None
+            height=0
         )

--- a/cursor/data/test/cursor_test.py
+++ b/cursor/data/test/cursor_test.py
@@ -1,5 +1,6 @@
 from board.data import Point
 from cursor.data import Cursor, Color
+from datetime import datetime, timedelta
 import unittest
 
 
@@ -15,6 +16,22 @@ class CursorTestCase(unittest.TestCase):
         self.assertIn(cursor.color, Color)
         self.assertEqual(cursor.width, 0)
         self.assertEqual(cursor.height, 0)
+
+    def test_cursor_revive_at(self):
+        conn_id = "some id"
+        cursor = Cursor.create(conn_id)
+
+        self.assertIsNone(cursor.revive_at)
+
+        # revive_at이 지나지 않음
+        hour_later = datetime.now() + timedelta(hours=1)
+        cursor.revive_at = hour_later
+        self.assertEqual(cursor.revive_at, hour_later)
+
+        # revive_at이 지남
+        hour_earlier = datetime.now() - timedelta(hours=1)
+        cursor.revive_at = hour_earlier
+        self.assertIsNone(cursor.revive_at)
 
     def test_check_interactable(self):
         # 0, 0
@@ -46,8 +63,7 @@ class CursorTestCase(unittest.TestCase):
             pointer=None,
             height=6,
             width=6,
-            color=Color.BLUE,
-            revive_at=None
+            color=Color.BLUE
         )
         cur_b = Cursor(
             conn_id="B",
@@ -55,8 +71,7 @@ class CursorTestCase(unittest.TestCase):
             pointer=None,
             height=7,
             width=7,
-            color=Color.BLUE,
-            revive_at=None
+            color=Color.BLUE
         )
         cur_c = Cursor(
             conn_id="C",
@@ -64,8 +79,7 @@ class CursorTestCase(unittest.TestCase):
             pointer=None,
             height=4,
             width=4,
-            color=Color.BLUE,
-            revive_at=None
+            color=Color.BLUE
         )
 
         self.assertTrue(cur_a.check_in_view(cur_c.position))

--- a/cursor/event/handler/internal/cursor_event_handler.py
+++ b/cursor/event/handler/internal/cursor_event_handler.py
@@ -109,9 +109,7 @@ class CursorEventHandler:
 
         # 커서 부활시간 확인
         if cursor.revive_at is not None:
-            if cursor.revive_at >= datetime.now():
-                return
-            cursor.revive_at = None
+            return
 
         # 뷰 바운더리 안에서 포인팅하는지 확인
         if not cursor.check_in_view(new_pointer):

--- a/cursor/event/handler/test/fixtures.py
+++ b/cursor/event/handler/test/fixtures.py
@@ -16,8 +16,7 @@ def setup_cursor_locations() -> tuple[Cursor]:
             pointer=None,
             height=6,
             width=6,
-            color=Color.YELLOW,
-            revive_at=None
+            color=Color.YELLOW
         ),
         "B": Cursor(
             conn_id="B",
@@ -25,8 +24,7 @@ def setup_cursor_locations() -> tuple[Cursor]:
             pointer=None,
             height=7,
             width=7,
-            color=Color.BLUE,
-            revive_at=None
+            color=Color.BLUE
         ),
         "C": Cursor(
             conn_id="C",
@@ -34,8 +32,7 @@ def setup_cursor_locations() -> tuple[Cursor]:
             pointer=None,
             height=4,
             width=4,
-            color=Color.PURPLE,
-            revive_at=None
+            color=Color.PURPLE
         )
     }
 


### PR DESCRIPTION
cursors 이벤트를 발행할 때, 각 커서의 revive_at이 지났는지 확인하고 있지 않아 이미 지난 revive_at도 클라이언트에 전달되고 있었습니다. 그래서 cursors 발행 로직에 검사를 추가하는 것보다, 기존 try-pointing에서 하던 검사를 cursor 안으로 가져와 try-pointing과 cursors 발행부에서 사용하였습니다.