### PR TITLE
explosion_count 추가

### DIFF
--- a/board/data/handler/internal/board.py
+++ b/board/data/handler/internal/board.py
@@ -297,6 +297,18 @@ class BoardHandler:
         return section
 
     @staticmethod
+    async def explosion_count():
+        sectios = await SectionStorage.get_all()
+        if sectios is None:
+            return 0
+
+        total = 0
+        for sec in sectios:
+            total += sec.get_explosion_count()
+
+        return total
+
+    @staticmethod
     async def _get_section_or_none(p: Point) -> Section | None:
         return await SectionStorage.get(p)
 

--- a/board/data/storage/internal/section_storage.py
+++ b/board/data/storage/internal/section_storage.py
@@ -45,6 +45,21 @@ class SectionStorage:
 
         return Section(p=p, data=bytearray(row[0]))
 
+    async def get_all() -> list[Section] | None:
+        row = None
+        cur = await db.execute(
+            f"SELECT x, y, data FROM {TABLE_NAME}",
+        )
+        row = await cur.fetchall()
+
+        if row is None:
+            return None
+
+        return [
+            Section(p=Point(x, y), data=bytearray(data))
+            for x, y, data in row
+        ]
+
     async def set(section: Section):
         await db.execute(
             f"""


### PR DESCRIPTION
지뢰 폭발 횟수 통계(event 사용 x, board로 찾음)
이유 -> 
지뢰 폭발을 효율적으로 감지할 수 없습니다.
그러나 Section이 이를 자체적으로 감지하여 처리한다면 쉽고 빠르게 폭발 횟수를 구할 수 있습니다.
이는 다음과 같은 상황에도 적용시킬 수 있습니다(열린 타일 개수, 찾은 지뢰 개수)

아직 클라이언트에게 어떻게 전달할지 생각하지 않았습니다.
http로 통신을 계획하였으나, 이는 event로 동작하는 현재 서버 구조상 많은 어려움이 예상됩니다.
이에 대한 좋은 의견 있다면 제시해주세요.
